### PR TITLE
Modal add

### DIFF
--- a/src/shared/Modal.tsx
+++ b/src/shared/Modal.tsx
@@ -1,0 +1,53 @@
+import { createElement as h, createSignal, Component, Show } from 'solid-js'
+//Component Properties
+const Modal: Component <{
+    messageHeader: string;
+    message: string;
+    confirmText: string;
+    declineText: string;
+  }> = (props) => {
+  const [show, setShow] = createSignal(false)
+
+  const handleOpen = () => {
+    setShow(true)
+  }
+
+  const handleClose = () => {
+    setShow(false)
+  }
+//Make sure you set an onConfirm function on the page or it will simply close the modal!
+  const handleConfirm = () => {
+    props.onConfirm()
+    setShow(false)
+  }
+  return (
+    <div>
+      <button class="bg-purple-600 hover:bg-purple-500 text-white font-bold py-2 px-4 rounded" onClick={handleOpen}>
+        Show Modal
+      </button>
+      <Show when={show()}>
+        <div class="fixed bottom-0 inset-x-0 px-4 pb-4 sm:inset-0 sm:flex sm:items-center sm:justify-center">
+          <div class="fixed inset-0 transition-opacity">
+            <div class="absolute inset-0 bg-gray-500 opacity-75"></div>
+          </div>
+          <div class="bg-black rounded-lg px-4 pt-5 pb-4 overflow-hidden shadow-xl transform transition-all sm:max-w-lg sm:w-full">
+            <div>
+              <div class="mb-4 text-lg black font-bold">{props.messageHeader}</div>
+              <div class="mb-4 text-lg black">{props.message}</div>
+              <div class="flex items-center justify-end">
+                <button class="text-red-500 hover:text-red-700" onClick={handleClose}>
+                    {props.declineText}
+                </button>
+                <button class="ml-3 bg-purple-600 hover:bg-purple-500 text-white font-bold py-2 px-4 rounded" onClick={handleConfirm}>
+                    {props.confirmText}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </Show>
+    </div>
+  )
+}
+
+export default Modal

--- a/src/shared/Modal.tsx
+++ b/src/shared/Modal.tsx
@@ -1,52 +1,47 @@
 import { createElement as h, createSignal, Component, Show } from 'solid-js'
 //Component Properties
-const Modal: Component <{
-    messageHeader: string;
-    message: string;
-    confirmText: string;
-    declineText: string;
-  }> = (props) => {
-  const [show, setShow] = createSignal(false)
+interface Props {
+  messageHeader: string;
+  message: string;
+  confirmText: string;
+  declineText: string;
+  onConfirm: () => void;
+}
 
-  const handleOpen = () => {
-    setShow(true)
-  }
+const Modal: Component <Props> = (props) => {
+  const [show, setShow] = createSignal(true)
 
   const handleClose = () => {
     setShow(false)
   }
-//Make sure you set an onConfirm function on the page or it will simply close the modal!
+//Make sure you set an onConfirm function on the page or it will simply close the modal without performing a task!!
   const handleConfirm = () => {
     props.onConfirm()
     setShow(false)
   }
+  
   return (
-    <div>
-      <button class="bg-purple-600 hover:bg-purple-500 text-white font-bold py-2 px-4 rounded" onClick={handleOpen}>
-        Show Modal
-      </button>
-      <Show when={show()}>
-        <div class="fixed bottom-0 inset-x-0 px-4 pb-4 sm:inset-0 sm:flex sm:items-center sm:justify-center">
-          <div class="fixed inset-0 transition-opacity">
-            <div class="absolute inset-0 bg-gray-500 opacity-75"></div>
-          </div>
-          <div class="bg-black rounded-lg px-4 pt-5 pb-4 overflow-hidden shadow-xl transform transition-all sm:max-w-lg sm:w-full">
-            <div>
-              <div class="mb-4 text-lg black font-bold">{props.messageHeader}</div>
-              <div class="mb-4 text-lg black">{props.message}</div>
-              <div class="flex items-center justify-end">
-                <button class="text-red-500 hover:text-red-700" onClick={handleClose}>
-                    {props.declineText}
-                </button>
-                <button class="ml-3 bg-purple-600 hover:bg-purple-500 text-white font-bold py-2 px-4 rounded" onClick={handleConfirm}>
-                    {props.confirmText}
-                </button>
-              </div>
+    <Show when={show()}>
+      <div class="fixed bottom-0 inset-x-0 px-4 pb-4 sm:inset-0 sm:flex sm:items-center sm:justify-center">
+        <div class="fixed inset-0 transition-opacity">
+          <div class="absolute inset-0 bg-gray-500 opacity-75"></div>
+        </div>
+        <div class="bg-black rounded-lg px-4 pt-5 pb-4 overflow-hidden shadow-xl transform transition-all sm:max-w-lg sm:w-full">
+          <div>
+            <div class="mb-4 text-lg black font-bold">{props.messageHeader}</div>
+            <div class="mb-4 text-lg black">{props.message}</div>
+            <div class="flex items-center justify-end">
+              <button class="text-red-500 hover:text-red-700" onClick={handleClose}>
+                  {props.declineText}
+              </button>
+              <button class="ml-3 bg-purple-600 hover:bg-purple-500 text-white font-bold py-2 px-4 rounded" onClick={handleConfirm}>
+                  {props.confirmText}
+              </button>
             </div>
           </div>
         </div>
-      </Show>
-    </div>
+      </div>
+    </Show>
   )
 }
 

--- a/src/shared/Modal.tsx
+++ b/src/shared/Modal.tsx
@@ -1,5 +1,5 @@
-import { createSignal, Component, Show } from 'solid-js'
-//Component Properties
+import { createSignal, Component, Show } from "solid-js";
+// Component Properties
 interface Props {
   messageHeader: string;
   message: string;
@@ -8,41 +8,49 @@ interface Props {
   onConfirm: () => void;
 }
 
-const Modal: Component <Props> = (props) => {
-  const [show, setShow] = createSignal(true)
+const Modal: Component<Props> = (props) => {
+  const [show, setShow] = createSignal(true);
 
   const handleClose = () => {
-    setShow(false)
-  }
-//Make sure you set an onConfirm function on the page or it will simply close the modal without performing a task!!
+    setShow(false);
+  };
+  // Make sure you set an onConfirm function on the page or it will simply close the modal without performing a task!!
   const handleConfirm = () => {
-    props.onConfirm()
-    setShow(false)
-  }
-  
+    props.onConfirm();
+    setShow(false);
+  };
+
   return (
     <Show when={show()}>
-      <div class="fixed bottom-0 inset-x-0 px-4 pb-4 sm:inset-0 sm:flex sm:items-center sm:justify-center">
+      <div class="fixed inset-x-0 bottom-0 px-4 pb-4 sm:inset-0 sm:flex sm:items-center sm:justify-center">
         <div class="fixed inset-0 transition-opacity">
-          <div class="absolute inset-0 bg-gray-500 opacity-75"></div>
+          <div class="absolute inset-0 bg-gray-500 opacity-75" />
         </div>
-        <div class="bg-black rounded-lg px-4 pt-5 pb-4 overflow-hidden shadow-xl transform transition-all sm:max-w-lg sm:w-full">
+        <div class="overflow-hidden rounded-lg bg-black px-4 pt-5 pb-4 shadow-xl transition-all sm:w-full sm:max-w-lg">
           <div>
-            <div class="mb-4 text-lg black font-bold">{props.messageHeader}</div>
-            <div class="mb-4 text-lg black">{props.message}</div>
+            <div class="black mb-4 text-lg font-bold">
+              {props.messageHeader}
+            </div>
+            <div class="black mb-4 text-lg">{props.message}</div>
             <div class="flex items-center justify-end">
-              <button class="text-red-500 hover:text-red-700" onClick={handleClose}>
-                  {props.declineText}
+              <button
+                class="text-red-500 hover:text-red-700"
+                onClick={handleClose}
+              >
+                {props.declineText}
               </button>
-              <button class="ml-3 bg-purple-600 hover:bg-purple-500 text-white font-bold py-2 px-4 rounded" onClick={handleConfirm}>
-                  {props.confirmText}
+              <button
+                class="ml-3 rounded bg-purple-600 py-2 px-4 font-bold text-white hover:bg-purple-500"
+                onClick={handleConfirm}
+              >
+                {props.confirmText}
               </button>
             </div>
           </div>
         </div>
       </div>
     </Show>
-  )
-}
+  );
+};
 
-export default Modal
+export default Modal;

--- a/src/shared/Modal.tsx
+++ b/src/shared/Modal.tsx
@@ -1,4 +1,4 @@
-import { createElement as h, createSignal, Component, Show } from 'solid-js'
+import { createSignal, Component, Show } from 'solid-js'
 //Component Properties
 interface Props {
   messageHeader: string;


### PR DESCRIPTION
Adds in basic confirm/decline modal. 
![image](https://user-images.githubusercontent.com/26259870/218222979-2c187435-9d0b-492e-954a-65faa84e4203.png)


Example of Usage:
```
import { Component, Solid, createSignal, Show } from "solid-js";
import { JSX } from "solid-js/jsx-runtime";
import Modal from '../../shared/Modal'
import PageHeader from '../../shared/PageHeader'
const [showModal, setShowModal] = createSignal(false)

const handleConfirm = () => {
  console.log('Modal confirmed')
}

const ModalTest = () => (
  <div>
    <button id="showModal" onClick={() => setShowModal(true)}> Show Modal </button>
    <Show when={showModal()}>
      <Modal messageHeader="Confirm Action" message="Are you sure you want to confirm this action?" confirmText="Confirm" declineText="Cancel" onConfirm={handleConfirm} />
    </Show>
  </div>
)

export default ModalTest;
```